### PR TITLE
INT-1150 do not parse index sizes separately anymore

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,14 +112,6 @@ var Collection = AmpersandModel.extend({
       }
     }
   },
-  parse: function(d) {
-    if (d.index_sizes) {
-      each(d.indexes, function(data, name) {
-        d.indexes[name].size = d.index_sizes[name];
-      });
-    }
-    return d;
-  },
   serialize: function() {
     var res = this.getAttributes({
       props: true,


### PR DESCRIPTION
indexes from the new index-model include sizes already. there is no need to set them separately in the parse function anymore (in fact, it breaks indexes now).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/collection-model/14)

<!-- Reviewable:end -->
